### PR TITLE
Fix checkbox label

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_modules_opc_billing_address.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_opc_billing_address.php
@@ -29,7 +29,7 @@ if (!$flagDisablePaymentAddressChange) {
 ?>
             <div class="custom-control custom-checkbox">
                 <?php echo zen_draw_checkbox_field("add_address['bill']", '1', false, 'id="opc-add-bill"' . $parameters); ?>
-                <label class="checkboxLabel custom-control-label" for="add_address['bill']" title="<?php echo TITLE_ADD_TO_ADDRESS_BOOK; ?>"><?php echo TEXT_ADD_TO_ADDRESS_BOOK; ?></label>
+                <label class="checkboxLabel custom-control-label" for="opc-add-bill" title="<?php echo TITLE_ADD_TO_ADDRESS_BOOK; ?>"><?php echo TEXT_ADD_TO_ADDRESS_BOOK; ?></label>
             </div>
 <?php
     }

--- a/includes/templates/bootstrap/templates/tpl_modules_opc_shipping_address.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_opc_shipping_address.php
@@ -44,7 +44,7 @@ if ($is_virtual_order) {
 ?>
                 <div class="custom-control custom-checkbox">
                     <?php echo zen_draw_checkbox_field("add_address['ship']", '1', false, 'id="opc-add-ship"' . $parameters); ?>
-                    <label class="checkboxLabel custom-control-label" for="add_address['ship']" title="<?php echo TITLE_ADD_TO_ADDRESS_BOOK; ?>"><?php echo TEXT_ADD_TO_ADDRESS_BOOK; ?></label>
+                    <label class="checkboxLabel custom-control-label" for="opc-add-ship" title="<?php echo TITLE_ADD_TO_ADDRESS_BOOK; ?>"><?php echo TEXT_ADD_TO_ADDRESS_BOOK; ?></label>
                 </div>
 <?php
         }


### PR DESCRIPTION
The "Add to Address Book" checkboxes, styled with Bootstrap, cannot be checked unless the label `for` attribute references the checkbox id (not the checkbox name).